### PR TITLE
Updated the react-native-linear-gradient dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.1",
   "dependencies": {
     "react-native-keep-awake": "^2.0.6",
-    "react-native-linear-gradient": "^2.3.0",
+    "react-native-linear-gradient": "2.3.0",
     "react-native-orientation": "^3.1.0",
     "react-native-slider": "https://github.com/abbasfreestyle/react-native-slider.git",
     "react-native-vector-icons": "^4.4.2",


### PR DESCRIPTION
 Updated the react-native-linear-gradient dependency version to only use version 2.3.0 because anything higher breaks the build process and app. The issue for this is https://github.com/abbasfreestyle/react-native-af-video-player/issues/80