### PR TITLE
fix(): remove faulty RN slider

### DIFF
--- a/components/Scrubber.js
+++ b/components/Scrubber.js
@@ -2,9 +2,7 @@ import React from 'react' // eslint-disable-line
 import PropTypes from 'prop-types'
 import {
   View,
-  Platform,
   StyleSheet,
-  Slider as RNSlider
 } from 'react-native'
 import Slider from 'react-native-slider'
 
@@ -12,9 +10,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center'
-  },
-  slider: {
-    marginHorizontal: -10
   },
   thumbStyle: {
     width: 15,
@@ -30,29 +25,17 @@ const Scrubber = (props) => {
   const { progress, theme, onSeek, onSeekRelease } = props
   return (
     <View style={styles.container}>
-      { Platform.OS === 'ios' ?
-        <Slider
-          onValueChange={val => onSeek(val)}
-          onSlidingComplete={val => onSeekRelease(val)}
-          value={progress === Number.POSITIVE_INFINITY ? 0 : progress}
-          thumbTintColor={theme.scrubberThumb}
-          thumbStyle={styles.thumbStyle}
-          trackStyle={styles.trackStyle}
-          minimumTrackTintColor={theme.scrubberBar}
-          maximumTrackTintColor={trackColor}
-          trackClickable
-        />
-      :
-        <RNSlider
-          style={styles.slider}
-          onValueChange={val => onSeek(val)}
-          onSlidingComplete={val => onSeekRelease(val)}
-          value={progress}
-          thumbTintColor={theme.scrubberThumb}
-          minimumTrackTintColor={theme.scrubberBar}
-          maximumTrackTintColor={trackColor}
-        />
-      }
+      <Slider
+        onValueChange={val => onSeek(val)}
+        onSlidingComplete={val => onSeekRelease(val)}
+        value={progress === Number.POSITIVE_INFINITY ? 0 : progress}
+        thumbTintColor={theme.scrubberThumb}
+        thumbStyle={styles.thumbStyle}
+        trackStyle={styles.trackStyle}
+        minimumTrackTintColor={theme.scrubberBar}
+        maximumTrackTintColor={trackColor}
+        trackClickable
+      />
     </View>
   )
 }


### PR DESCRIPTION
Default RN slider caused some crashes in dev. and production, there are multiple workarounds to fix that with lodash or timeout per seek. As @abbasfreestyle used another slider for IOS, I switched the Android slider with 'react-native-slider'