### PR TITLE
Retry button issue fixed! (#101)

### DIFF
--- a/components/Video.js
+++ b/components/Video.js
@@ -318,7 +318,7 @@ class Video extends Component {
         <Icons
           name="replay"
           size={60}
-          color={this.props.theme}
+          color={this.props.theme.center && 'white'}
           onPress={() => this.setState({ renderError: false })}
         />
       </Animated.View>


### PR DESCRIPTION
Hi,
Sometimes "retry button" could not be seen and clicked on Player when any error occurred during video processing. Reason of this, the button color hadn't been defined correctly. I fixed it. 

You can review it.

Thanks.