### PR TITLE
Added prop to hide the fullscreen icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ title                 | string   | No       | ''                        | Adds a
 placeholder           | string   | No       | undefined                 | Adds an image placeholder while it's loading and stopped at the beginning
 logo                  | string   | No       | undefined                 | Adds an image logo at the top left corner of the video
 theme                 | string   | No       | 'white'                   | Adds an optional theme colour to the players controls
+hideFullScreenControl | bool     | No       | false                     | This hides the full screen control
 style                 | number, object | No | {}                        | Apply styles directly to the Video player (ignored in fullscreen mode)
 resizeMode            | string   | No       | 'contain'                 | Fills the whole screen at aspect ratio. contain, cover etc
 rotateToFullScreen    | bool     | No       | false                     | Tapping the fullscreen button will rotate the screen. Also rotating the screen will automatically switch to fullscreen mode

--- a/components/ControlBar.js
+++ b/components/ControlBar.js
@@ -23,7 +23,8 @@ const ControlBar = (props) => {
     muted,
     fullscreen,
     theme,
-    inlineOnly
+    inlineOnly,
+    hideFullScreenControl
   } = props
 
   return (
@@ -45,7 +46,7 @@ const ControlBar = (props) => {
         size={20}
       />
       <Time time={duration} theme={theme.duration} />
-      { !inlineOnly &&
+      { !inlineOnly || !hideFullScreenControl &&
       <ToggleIcon
         paddingRight
         onPress={() => props.toggleFS()}
@@ -66,6 +67,7 @@ ControlBar.propTypes = {
   fullscreen: PropTypes.bool.isRequired,
   muted: PropTypes.bool.isRequired,
   inlineOnly: PropTypes.bool.isRequired,
+  hideFullScreenControl: PropTypes.bool.isRequired,
   progress: PropTypes.number.isRequired,
   currentTime: PropTypes.number.isRequired,
   duration: PropTypes.number.isRequired,

--- a/components/Controls.js
+++ b/components/Controls.js
@@ -127,7 +127,8 @@ class Controls extends Component {
       currentTime,
       duration,
       theme,
-      inlineOnly
+      inlineOnly,
+      hideFullScreenControl
     } = this.props
 
     const { center, ...controlBar } = theme
@@ -164,6 +165,7 @@ class Controls extends Component {
             duration={duration}
             theme={controlBar}
             inlineOnly={inlineOnly}
+            hideFullScreenControl={hideFullScreenControl}
           />
         </Animated.View>
       </Touchable>
@@ -188,6 +190,7 @@ Controls.propTypes = {
   onMorePress: PropTypes.func.isRequired,
   paused: PropTypes.bool.isRequired,
   inlineOnly: PropTypes.bool.isRequired,
+  hideFullScreenControl: PropTypes.bool.isRequired,
   fullscreen: PropTypes.bool.isRequired,
   muted: PropTypes.bool.isRequired,
   more: PropTypes.bool.isRequired,

--- a/components/Video.js
+++ b/components/Video.js
@@ -354,6 +354,7 @@ class Video extends Component {
       playInBackground,
       playWhenInactive,
       controlDuration,
+      hideFullScreenControl
     } = this.props
 
     const inline = {
@@ -423,6 +424,7 @@ class Video extends Component {
           theme={setTheme}
           inlineOnly={inlineOnly}
           controlDuration={controlDuration}
+          hideFullScreenControl={hideFullScreenControl}
         />
       </Animated.View>
     )
@@ -454,6 +456,7 @@ Video.propTypes = {
   loop: PropTypes.bool,
   autoPlay: PropTypes.bool,
   inlineOnly: PropTypes.bool,
+  hideFullScreenControl: PropTypes.bool,
   fullScreenOnly: PropTypes.bool,
   playInBackground: PropTypes.bool,
   playWhenInactive: PropTypes.bool,


### PR DESCRIPTION
I have added a prop to hide the fullscreen control as this isn't always needed. If you remove this with the "inlineOnly" this effects the landscape view of the video. 

I have also updated the README.md with the new prop, happy to talk though if you want me to @abbasfreestyle 😄